### PR TITLE
Fix for discrepancy between panel and report results

### DIFF
--- a/services/config.rb
+++ b/services/config.rb
@@ -280,8 +280,17 @@ const CloudCoreoJSRunner = require('cloudcoreo-jsrunner-commons');
 const AuditEC2ATK = new CloudCoreoJSRunner(JSON_INPUT, VARIABLES);
 const notifiers = AuditEC2ATK.getNotifiers();
 const violations = JSON.stringify(AuditEC2ATK.getJSONForAuditPanel());
+const OutputViolations = JSON.stringify(AuditEC2ATK.getJSONForAuditPanel().violations)
+coreoExport('output_violations', OutputViolations);
 callback(notifiers);
   EOH
+end
+
+coreo_uni_util_variables "update-rule-runner" do
+ action :set
+ variables([
+               {'COMPOSITE::coreo_aws_rule_runner_ec2.advise-ec2-atk.report' => 'COMPOSITE::coreo_uni_util_jsrunner.tags-to-notifiers-array-ec2-atk.output_violations'}
+           ])
 end
 
 # Send ec2-atk for email


### PR DESCRIPTION
This was that issue we came across on Tuesday where there was a difference between the panel results and the html_report results for ec2-aws-atk and the AMI version alert. 